### PR TITLE
Allow parsing of HOCR file generated by latest Tesseract

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,9 +18,13 @@
 
     Hocr.prototype.processBox = function(str) {
       var coords;
+      var strTokenLength = 5;
       if (str.indexOf('bbox') === 0) {
         coords = str.split(' ');
-        if (coords.length !== 5) {
+        if(str.indexOf('x_wconf' === 0)) {
+          strTokenLength = 7;
+        }
+        if (coords.length !== strTokenLength) {
           return str;
         } else {
           return {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "node-hocr",
   "description": "Hocr parser for Node.js",
   "author": "Vincent Giersch <mail@vincent.sh>",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "license": "MIT",
   "dependencies": {
     "coffee-script": ">= 1.1.1",


### PR DESCRIPTION
When using this tool with a file generated by Tesseract 3.02 it expects the bounding box coordinates to be in the following format:

```
title='bbox 289 432 360 451'
```

However, when using Tesseract 3.03 the following is output:

```
title='bbox 289 432 360 451; x_wconf 85'
```

This fix addresses this change whilst allowing for backwards compatibility.

Please let me know what you think. If you are happy with this then I can also update the `.coffee` file as well.
